### PR TITLE
PHP8 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 executors:
+  php8_0:
+    docker:
+      - image: circleci/php:8.0
   php7_4:
     docker:
       - image: circleci/php:7.4
@@ -38,6 +41,10 @@ commands:
       #    path: /tmp/artifacts
 
 jobs:
+  php80:
+    executor: php8_0
+    steps:
+      - composer_install
   php74:
     executor: php7_4
     steps:
@@ -58,6 +65,7 @@ jobs:
 workflows:
   test:
     jobs:
+      - php80
       - php74
       - php73
       - php72

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,6 @@ executors:
   php7_3:
     docker:
       - image: circleci/php:7.3
-  php7_2:
-    docker:
-      - image: circleci/php:7.2
-  php7_1:
-    docker:
-      - image: circleci/php:7.1
 
 orbs:
   codecov: codecov/codecov@1.0.4
@@ -53,14 +47,6 @@ jobs:
     executor: php7_3
     steps:
       - composer_install
-  php72:
-    executor: php7_2
-    steps:
-      - composer_install
-  php71:
-    executor: php7_1
-    steps:
-      - composer_install
 
 workflows:
   test:
@@ -68,5 +54,4 @@ workflows:
       - php80
       - php74
       - php73
-      - php72
-      - php71
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "search",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3|^8.0",
+        "php": "^7.1.3|^7.2|^7.2.5|^7.3|^8.0",
         "laravel/framework":"^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
     "description": "search",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0",
         "laravel/framework":"^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
-        "orchestra/testbench": "^3.5"
+        "phpunit/phpunit": "^7.5|^9.0",
+        "orchestra/testbench": "^3.5|^6.9",
+        "laravel/legacy-factories": "^1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- update PHP to v8
   - update `orchestra/testbench` to `^6.9`
   - update `phpunit/phpunit` to `^9.0`
- add PHP versions required by each Laravel major versions to `composer.json` for CircleCI inspection
- add `laravel/legacy-factories` for testing with Laravel8
   - delete CircleCI workflow for PHP7.1 and 7.1 environment